### PR TITLE
Add Deferred Bug status

### DIFF
--- a/developer/how-to/triage-bugs.rst
+++ b/developer/how-to/triage-bugs.rst
@@ -51,17 +51,19 @@ These are the questions we ask when triaging bug reports about
    as a duplicate of the older bug.
 4. **Is it something we will not do and would not accept a patch to
    do?** If so, mark it as *Won't Fix*.
-5. **Is it an operational request?** If yes, convert it to a question.
-6. **When are we likely to fix this?** Set the importance to show when
+5. **Is it something we will not now and defer to a later date?** If so, mark
+   it as *Deferred*.
+6. **Is it an operational request?** If yes, convert it to a question.
+7. **When are we likely to fix this?** Set the importance to show when
    we'll get to fixing this bug (`read more about choosing an
    importance <#importance>`__).
-7. **Does the report have enough detail?** If we couldn't replicate or
+8. **Does the report have enough detail?** If we couldn't replicate or
    otherwise begin work on the bug with the information provided,
    request further information from the reporter and mark it as
    *Incomplete* and move to the next bug. If someone has already asked
    for more info and the reporter has replied, change the status from
    *Incomplete* to *Triaged*.
-8. **Set the status to Triaged**.
+9. **Set the status to Triaged**.
 
 If you're uncertain what importance to give a bug, chat with another
 engineer. If there's a disagreement, let common sense and courtesy take

--- a/user/reference/bug-tracker-api/bug-statuses.rst
+++ b/user/reference/bug-tracker-api/bug-statuses.rst
@@ -11,7 +11,7 @@ want to add an extra layer of quality control to your bug triage.
 Whereas anyone can set most of the bug statuses, which makes it easy for
 new contributors to get involved, there are two additional bug statuses
 
--  *Triaged* and *Won't Fix* - that are available only to your project's
+-  *Triaged*, *Won't Fix* and *Deferred* - that are available only to your project's
    owner, bug supervisor and the relevant drivers.
 
 Available to everyone
@@ -46,6 +46,8 @@ Only available to the bug supervisor
    contains all information a developer needs to start work on a fix.
 -  **Won't Fix:** this is acknowledged as a genuine bug but the project
    has no plans to fix it.
+-  **Deferred:** the bug supervisor considers that the bug fix will be deferred
+   to a later date.
 
 Translating external bug statuses
 ---------------------------------


### PR DESCRIPTION
Add `Deferred` status to `how-to/triage-bugs` and `reference/bug-tracker-api/bug-statuses` as we added this status recently.